### PR TITLE
Add non-zero exit status upon compilation failure

### DIFF
--- a/src/main/java/org/jcoffeescript/Main.java
+++ b/src/main/java/org/jcoffeescript/Main.java
@@ -37,6 +37,7 @@ public class Main {
             out.print(new JCoffeeScriptCompiler(options).compile(readSourceFrom(in)));
         } catch (JCoffeeScriptCompileException e) {
             System.err.println(e.getMessage());
+            System.exit(1);
         }
     }
 


### PR DESCRIPTION
Hello.

Currently it's rather difficult to know if compilation succeeded or failed - one would have to parse the output, which makes using jcoffeescript in a build scripts rather difficult. I added non-ero exit status upon compilation failure.
