### PR TITLE
Allow setting options after compiler is constructed

### DIFF
--- a/src/main/java/org/jcoffeescript/JCoffeeScriptCompiler.java
+++ b/src/main/java/org/jcoffeescript/JCoffeeScriptCompiler.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 public class JCoffeeScriptCompiler {
 
     private final Scriptable globalScope;
-    private final Options options;
+    private Options options;
 
 	 public JCoffeeScriptCompiler() {
         this(Collections.<Option>emptyList());
@@ -64,6 +64,10 @@ public class JCoffeeScriptCompiler {
             throw new Error(e); // This should never happen
         }
 
+        this.options = new Options(options);
+    }
+
+    public void setOptions(Collection<Option> options) {
         this.options = new Options(options);
     }
 


### PR DESCRIPTION
Just adding a setOptions() method.

This is desirable because individual snippets of coffee may have different preferences on whether they want to be compiled with 'bare' or not.  Additionally, creating a new instance of the compiler every time seems wasteful given the relatively complicated constructor.

FYI, I'm using JCoffeeScript in https://github.com/robfig/play-coffee 

Thanks!
-Rob
